### PR TITLE
fix(skill): quote description in SKILL.md frontmatter for YAML parsing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: baro7
-description: Non-breaking UI (layout/scroll/shell intact) and token-optimized: compact core, load docs by scope. Use when building or editing web apps so structure never breaks and agents use fewer tokens.
+description: "Non-breaking UI (layout/scroll/shell intact) and token-optimized: compact core, load docs by scope. Use when building or editing web apps so structure never breaks and agents use fewer tokens."
 ---
 
 # baro7 — Application Development & UI Structure


### PR DESCRIPTION
Closes #5

- Quote `description` in SKILL.md so colons (e.g. "token-optimized: compact core") are not parsed as YAML keys.
- Ensures `npx skills add` and other parsers recognize the skill correctly.

Made with [Cursor](https://cursor.com)